### PR TITLE
Fix menu typo for Conditional Statements page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ pages:
   - Advanced Functions:
     - Arrays and Loops: 'AdvancedFunctions/Arrays_and_Loops.md'
     - Calculations: 'AdvancedFunctions/Calculations.md'
-    - Contional Statements: 'AdvancedFunctions/Conditional_Statements.md'
+    - Conditional Statements: 'AdvancedFunctions/Conditional_Statements.md'
     - Custom Functions: 'AdvancedFunctions/Custom_Functions.md'
     - Import: 'AdvancedFunctions/Import.md'
   - Vanilla:


### PR DESCRIPTION
`Contional` -> `Conditional`