### PR TITLE
Added docs for PneumaticCraft: Repressurized

### DIFF
--- a/docs/Mods/PneumaticCraft_Repressurized/Assembly.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/Assembly.md
@@ -1,0 +1,45 @@
+# Robotic Assembly System
+
+The Robotic Assembly System is a multiblock consisting of the Assembly Controller, Assembly I/O Units, Assembly Platform, Assembly Laser and Assembly Drill.  It converts input items to output items using the laser and/or drill.
+
+There are several functions for adding and removing recipes, depending on whether the recipe requires use of the laser, the drill, or both.
+
+## Calling
+
+You can call the Assembly package using `mods.pneumaticcraft.assembly`.
+
+## Removing
+
+These functions remove the first recipe they find with the given [IItemStack](/Vanilla/Items/IItemStack) `output`:
+
+```java
+mods.pneumaticcraft.assembly.removeLaserRecipe(IItemStack output);
+mods.pneumaticcraft.assembly.removeDrillRecipe(IItemStack output);
+mods.pneumaticcraft.assembly.removeDrillLaserRecipe(IItemStack output);
+
+// Examples
+mods.pneumaticcraft.assembly.removeLaserRecipe(<pneumaticcraft:aphorism_tile>);
+mods.pneumaticcraft.assembly.removeDrillRecipe(<pneumaticcraft:pressure_chamber_valve>);
+```
+
+These functions remove *all* recipes currently defined for the Assembly System:
+
+```java
+mods.pneumaticcraft.assembly.removeAllLaserRecipes();
+mods.pneumaticcraft.assembly.removeAllDrillRecipes();
+mods.pneumaticcraft.assembly.removeAllDrillLaserRecipes();
+```
+
+## Adding
+
+These functions are used to add new recipes for the assembly system:
+
+```java
+mods.pneumaticcraft.assembly.addLaserRecipe(IItemStack input, IItemStack output)
+mods.pneumaticcraft.assembly.addDrillRecipe(IItemStack input, IItemStack output)
+mods.pneumaticcraft.assembly.addDrillLaserRecipe(IItemStack input, IItemStack output)
+
+// Examples
+mods.pneumaticcraft.assembly.addLaserRecipe(<pneumaticcraft:ingot_iron_compressed> * 2, <pneumaticcraft:compressed_iron_gear>);
+```
+

--- a/docs/Mods/PneumaticCraft_Repressurized/HeatFrameCooling.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/HeatFrameCooling.md
@@ -1,0 +1,35 @@
+# Heat Frame Cooling
+
+Heat Frame Cooling can be used to transform one item into another by placing items in a chest or other inventory with a Heat Frame attached, and cooling it to below 0°C (commonly using a Vortex Tube).
+
+## Calling
+
+You can call the Heat Frame Cooling package using `mods.pneumaticcraft.heatframecooling`
+
+## Removing
+
+This function removes the first recipe it finds with the given [IIngredient](/Vanilla/Variable_Types/IIngredient) `output`:
+
+```
+mods.pneumaticcraft.heatframecooling.removeRecipe(IIngredient output);
+// Example
+mods.pneumaticcraft.heatframecooling.removeRecipe(<minecraft:obsidian>);
+```
+
+This function removes *all* Heat Frame Cooling recipes:
+
+```
+mods.pneumaticcraft.heatframecooling.removeAllRecipes();
+```
+
+## Adding
+
+These functions are used to add new recipes for the Heat Frame Cooling system:
+
+```
+mods.pneumaticcraft.heatframecooling.addRecipe(IItemStack input, IItemStack output);
+mods.pneumaticcraft.heatframecooling.addRecipe(IOreDictEntry input, IItemStack output);
+
+// Example
+mods.pneumaticcraft.heatframecooling.addRecipe(<minecraft:slime_ball>, <minecraft:snow_ball>);
+```

--- a/docs/Mods/PneumaticCraft_Repressurized/PneumaticCraft_Repressurized.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/PneumaticCraft_Repressurized.md
@@ -1,0 +1,9 @@
+# PneumaticCraft: Repressurized
+
+PneumaticCraft: Repressurized is a port of MineMaarten's PneumaticCraft mod to Minecraft 1.12.2. It's a tech mod using the concept of pressurized air as a power system, and adds some cool gadgets including a fully-programmable drone automation system.
+
+## CraftTweaker Support
+
+PneumaticCraft: Repressurized comes with its own native CraftTweaker support.  Therefore, please raise any CraftTweaker-related issues at the [PneumaticCraft: Repressurized issue tracker](https://github.com/TeamPneumatic/pnc-repressurized/issues).
+
+Note that the support documented here is for PneumaticCraft: Repressurized *only*; none of this applies to the original PneumaticCraft mod found in MC1.8.9 and earlier.

--- a/docs/Mods/PneumaticCraft_Repressurized/PressureChamber.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/PressureChamber.md
@@ -1,0 +1,35 @@
+# Pressure Chamber
+
+The Pressure Chamber is a multiblock structure which uses compressed air to convert one or more input items into one or more output items.  Pressure Chamber recipes have an associated pressure value, which is the air pressure in bar required to perform the conversion.
+
+## Calling
+
+You can call the Pressure Chamber package using `mods.pneumaticcraft.pressurechamber`.
+
+## Removing
+
+This function removes the first recipe it finds with the given [IIngredient](/Vanilla/Variable_Types/IIngredient) `output`:
+
+```
+mods.pneumaticcraft.pressurechamber.removeRecipe(IIngredient output);
+// Example
+mods.pneumaticcraft.pressurechamber.removeRecipe(<pneumaticcraft:ingot_iron_compressed>);
+```
+
+This function removes *all* Pressure Chamber recipes:
+
+```
+mods.pneumaticcraft.pressurechamber.removeAllRecipes();
+```
+
+## Adding
+
+This function is used to add new recipes to the Pressure Chamber:
+
+```
+mods.pneumaticcraft.pressurechamber.addRecipe(IIngredient[] input, double pressure, IItemStack[] output);
+
+// Example
+mods.pneumaticcraft.pressurechamber.addRecipe([<minecraft:gold_ingot> * 2,<minecraft:apple>], 2.0, [<minecraft:golden_apple>]);
+```
+

--- a/docs/Mods/PneumaticCraft_Repressurized/Refinery.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/Refinery.md
@@ -1,0 +1,40 @@
+# Refinery
+
+The Refinery is a multiblock structure which uses heat to convert an input fluid to two or more output fluids.  The multiblock consists of two to four (inclusive) refinery blocks, and the number of possible output fluids is limited by the number of refinery blocks in the structure.
+
+Heat value is not part of the recipe; the refinery will start to process fluids at any temperature >= 100°C, but will work faster as the temperature rises.
+
+Note that it's possible to have two or more recipes with the same input, as long as the number of outputs is different.  In this case, the recipe producing the most possible outputs (given the number of refinery blocks) will be used.
+
+## Calling
+
+You can call the Refinery package using `mods.pneumaticcraft.refinery`.
+
+## Removing
+
+This function removes the first recipe it finds matching all of the given [IIngredient](/Vanilla/Variable_Types/IIngredient) `outputs`:
+
+```java
+mods.pneumaticcraft.refinery.removeRecipe(IIngredient[] outputs);
+```
+
+This function removes the first recipe it finds matching the given [IIngredient](/Vanilla/Variable_Types/IIngredient) `input`:
+
+```java
+mods.pneumaticcraft.refinery.removeRecipes(IIngredient input);
+```
+
+## Adding
+
+This function adds a new recipe to the Refinery:
+
+```java
+mods.pneumaticcraft.refinery.addRecipe(ILiquidStack input, ILiquidStack[] outputs);
+
+// Example
+// Both recipes use water as input
+// First recipe will be used in a 2-block refinery
+// Second recipe will be used in a 3- or 4-block refinery
+mods.pneumaticcraft.refinery.addRecipe(<liquid:water> * 10, [<liquid:lava> * 2, <liquid:oil> * 5]);
+mods.pneumaticcraft.refinery.addRecipe(<liquid:water> * 10, [<liquid:lava> * 2, <liquid:oil> * 5, <liquid:lpg> * 2]);
+```

--- a/docs/Mods/PneumaticCraft_Repressurized/ThermopneumaticProcessingPlant.md
+++ b/docs/Mods/PneumaticCraft_Repressurized/ThermopneumaticProcessingPlant.md
@@ -1,0 +1,44 @@
+# Thermopneumatic Processing Plant
+
+The Thermopneumatic Processing Plant (TPP) uses pressure and heat to convert one fluid and/or one solid ingredient to another fluid.  Temperatures should be specified in Kelvin: 273 K = 0°C (32°F), 373 K = 100°C (212°F).
+
+*Technically, 273.16 K = 0°C, but for the purposes of this mod it's simplified to an integer offset.*
+
+## Calling
+
+You can call the TPP package using `mods.pneumaticcraft.thermopneumaticprocessingplant`.
+
+## Removing
+
+This function removes the first recipe it finds with the given [IIngredient](/Vanilla/Variable_Types/IIngredient) `output`:
+
+```
+mods.pneumaticcraft.thermopneumaticprocessingplant.removeRecipe(IIngredient output);
+// Example
+mods.pneumaticcraft.thermopneumaticprocessingplant.removeRecipe(<liquid:lpg>);
+```
+
+This function removes *all* TPP recipes:
+
+```
+mods.pneumaticcraft.thermopneumaticprocessingplant.removeAllRecipes();
+```
+
+## Adding
+
+The following functions can be used to add recipes to the TPP:
+
+```java
+// Add a recipe converting an input item into an output fluid
+mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(IItemStack itemInput, double pressure, double temperature, ILiquidStack output);
+
+// Add a recipe converting an input fluid and item into an output fluid (item may be null)
+mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(ILiquidStack liquidInput, IItemStack itemInput, double pressure, double temperature, ILiquidStack output);
+
+// Example: convert water and redstone to some redstone fluid at 3.0 bar and 473K (200C)
+mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(<liquid:water>, <item:redstone>, 3.0, 473, <liquid:redstone> * 250);
+// Example: convert 10mB oil into 5mB lava at 3.0 bar and 473K
+mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(<liquid:oil> * 10, null, 3.0, 473, <liquid:lava> * 5);
+// Example: convert 1 netherrack into 50mB lava at 1.5 bar and 573K
+mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(<minecraft:netherrack>, 1.5, 573, <liquid:lava> * 50);
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,14 @@ pages:
       - Item Liquefier: 'Mods/PoweredThingies/ItemLiquefierTweaker.md'
       - Powder Maker: 'Mods/PoweredThingies/PowderMakerTweaker.md'
       - Powered Kiln: 'Mods/PoweredThingies/PoweredKilnTweaker.md'
+    - 'PneumaticCraft: Repressurized':
+      - 'About PneumaticCraft: Repressurized': 'Mods/PneumaticCraft_Repressurized/PneumaticCraft_Repressurized.md'
+      - Crafting:
+        - Assembly System: 'Mods/PneumaticCraft_Repressurized/Assembly.md'
+        - Heat Frame Cooling: 'Mods/PneumaticCraft_Repressurized/HeatFrameCooling.md'
+        - Pressure Chamber: 'Mods/PneumaticCraft_Repressurized/PressureChamber.md'
+        - Refinery: 'Mods/PneumaticCraft_Repressurized/Refinery.md'
+        - Thermopneumatic Processing: 'Mods/PneumaticCraft_Repressurized/ThermopneumaticProcessingPlant.md'
 
 # Do not edit in PRs below here
 site_name: Crafttweaker Documentation


### PR DESCRIPTION
This PR adds documentation for the five PneumaticCraft: Repressurized machines which have
CraftTweaker recipe support.