### PR TITLE
Fix function name in fake flint example

### DIFF
--- a/docs/Mods/ContentTweaker/Vanilla/Advanced_Functionality/Functions/IItemUse.md
+++ b/docs/Mods/ContentTweaker/Vanilla/Advanced_Functionality/Functions/IItemUse.md
@@ -34,7 +34,7 @@ item.onItemUse = function(player, world, pos, hand, facing, blockHit) {
     var firePos = pos.getOffset(facing, 1);
     if (world.getBlockState(firePos).isReplaceable(world, firePos)) {
         world.setBlockState(<block:minecraft:fire>, firePos);
-        player.getHeldItem(hand).damageItem(1, player);
+        player.getHeldItem(hand).damage(1, player);
         return ActionResult.success();
     }
 


### PR DESCRIPTION
.damage() is the proper name, ~~though it seems borked in CnT 4.4.1~~ works fine, 10/10 mod of the year